### PR TITLE
Move jupiterone.md file so support docs are auto-generated

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -5,20 +5,20 @@
 - Visualize Wazuh endpoint agents and the devices they protect in the JupiterOne
   graph.
 - Map endpoint agents to devices and devices to the employee who has or owns the
-  device.  
-- Monitor changes to Wazuh endpoint agents and devices using JupiterOne
-  alerts.
+  device.
+- Monitor changes to Wazuh endpoint agents and devices using JupiterOne alerts.
 
 ## How it Works
 
-- JupiterOne periodically fetches Wazuh endpoint agents and devices to update the graph.
+- JupiterOne periodically fetches Wazuh endpoint agents and devices to update
+  the graph.
 - Write JupiterOne queries to review and monitor updates to the graph.
 - Configure alerts to take action when the JupiterOne graph changes.
 
 ## Requirements
 
-- JupiterOne requires the Wazuh manager API base URL. JupiterOne also requires 
-the username and password to authenticate with the API.
+- JupiterOne requires the Wazuh manager API base URL. JupiterOne also requires
+  the username and password to authenticate with the API.
 - You must have permission in JupiterOne to install new integrations.
 
 ## Support
@@ -40,16 +40,18 @@ and a username and password to JupiterOne.
 1. From the configuration **Gear Icon**, select **Integrations**.
 2. Scroll to the **Wazuh** integration tile and click it.
 3. Click the **Add Configuration** button and configure the following settings:
-- Enter the **Account Name** by which you'd like to identify this Wazuh
-   account in JupiterOne. Ingested entities will have this value stored in
-   `tag.AccountName` when **Tag with Account Name** is checked.
+
+- Enter the **Account Name** by which you'd like to identify this Wazuh account
+  in JupiterOne. Ingested entities will have this value stored in
+  `tag.AccountName` when **Tag with Account Name** is checked.
 - Enter a **Description** that will further assist your team when identifying
-   the integration instance.
+  the integration instance.
 - Select a **Polling Interval** that you feel is sufficient for your monitoring
-   needs. You may leave this as `DISABLED` and manually execute the integration.
+  needs. You may leave this as `DISABLED` and manually execute the integration.
 - Enter the **Manager URL**, or the Wazuh API base URL.
 - Enter the **Username** used to authenticate with the Wazuh Manager.
 - Enter the **Password** associated with the username.
+
 4. Click **Create Configuration** once all values are provided.
 
 ## How to Uninstall

--- a/tools/docs.ts
+++ b/tools/docs.ts
@@ -3,7 +3,7 @@ import fs from "fs-extra";
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
 
 const packageNameSansOrg = pkg.name.split("/").pop();
-const baseDocsPath = `docs/jupiterone-io/${packageNameSansOrg}`;
+const baseDocsPath = `docs/jupiterone`;
 
 let docsExtension;
 if (fs.pathExistsSync(`${baseDocsPath}.md`)) {


### PR DESCRIPTION
The `docs` project is printing
```
Could not fetch documentation file for project graph-wazuh
```
because this path name was wrong.